### PR TITLE
Add module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/djherbis/atime
+
+go 1.11


### PR DESCRIPTION
This will be the requirement for go 1.17, as it will drop support for the GO111MODULE environment variable. For now, the minimum supported version for this as a go module is set at 1.11.